### PR TITLE
Feature/authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ end
 gem 'devise', '~> 4.9'
 
 gem 'letter_opener'
+
+gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -254,6 +255,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise (~> 4.9)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,7 +53,7 @@ footer {
   background-color: $black;
   color: $white;
   width: 100%;
-  padding: 10px 30px;
+  padding: 10px 31px;
 }
 
 main {
@@ -109,7 +109,7 @@ main {
 
       .bio {
         flex-basis: 100%;
-        margin-top: 20px;
+        margin-top: 21px;
       }
     }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -225,18 +225,19 @@ main {
   padding: 30px;
   border-radius: 5px;
   box-shadow: 0 4px 14px 0 rgba(70, 70, 70, 0.38);
+}
 
-  .form-control {
-    margin: 20px 0;
-  }
+.form-control {
+  margin: 20px 0;
+}
 
-  .form-control input:not([type="checkbox"]) {
-    width: 100%;
-    height: 40px;
-    margin: 5px 0;
-    padding: 5px 10px;
-    font-size: 17px;
-  }
+.form-control input:not([type="checkbox"]),
+.form-control textarea {
+  width: 100%;
+  height: 40px;
+  margin: 5px 0;
+  padding: 5px 10px;
+  font-size: 17px;
 }
 
 // BUTTON

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,8 +1,7 @@
 class CommentsController < ApplicationController
-  # before_action :set_post, only: [:create, :destroy]
+  before_action :set_post, only: [:create, :destroy]
 
   def create
-    @post = Post.find(params[:post_id])
     @comment = @post.comments.build(comment_params)
     @comment.author_id = current_user.id
 
@@ -16,7 +15,7 @@ class CommentsController < ApplicationController
   def destroy
     @comment = @post.comments.find(params[:id])
     @comment.destroy
-    redirect_to @post, notice: 'Comment was successfully deleted.'
+    redirect_to user_post_path(id: @post.id), notice: 'Comment was successfully deleted.'
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,5 @@
 class CommentsController < ApplicationController
+  # before action to set post
   before_action :set_post, only: %i[create destroy]
 
   def create

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :set_post, only: [:create, :destroy]
+  before_action :set_post, only: %i[create destroy]
 
   def create
     @comment = @post.comments.build(comment_params)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,12 +27,11 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    puts "Destroy action reached."
+    puts 'Destroy action reached.'
     @post = Post.find(params[:post_id])
     @post.destroy!
     redirect_to user_posts_path(author_id: @post.user.id), notice: 'Post was deleted successfully!'
   end
-
 
   private
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  load_and_authorize_resource
+  before_action :authenticate_user!, only: %i[create destroy]
   def index
     @user = User.includes(posts: { comments: :user }).find(params[:user_id])
     @posts = @user.posts
@@ -24,9 +26,21 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    puts "Destroy action reached."
+    @post = Post.find(params[:post_id])
+    @post.destroy!
+    redirect_to user_posts_path(author_id: @post.user.id), notice: 'Post was deleted successfully!'
+  end
+
+
   private
 
   def post_params
     params.require(:post).permit(:title, :text)
+  end
+
+  def set_post
+    @post = Post.find(params[:post_id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  # Loading and authorization of resources
   load_and_authorize_resource
   before_action :authenticate_user!, only: %i[create destroy]
   def index

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the user here. For example:
+    #
+    #   return unless user.present?
+    #   can :read, :all
+    #   return unless user.admin?
+    #   can :manage, :all
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, published: true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,32 +1,20 @@
-# frozen_string_literal: true
-
 class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the user here. For example:
-    #
-    #   return unless user.present?
-    #   can :read, :all
-    #   return unless user.admin?
-    #   can :manage, :all
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, published: true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+    if user.role == 'admin'
+      can :manage, :all
+    else
+      can :read, :all
+      can :create, Post, author_id: user.id
+      can :create, Comment, author_id: user.id
+      can :create, Like
+      can :destroy, Post do |post|
+        post.author_id == user.id
+      end
+      can :destroy, Comment do |comment|
+        comment.author_id == user.id
+      end
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,8 +4,8 @@ class Post < ApplicationRecord
   validates :likes_counter, numericality: { only_integer: true }, comparison: { greater_than_or_equal_to: 0 }
 
   belongs_to :user, foreign_key: 'author_id'
-  has_many :comments
-  has_many :likes
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   after_create :increment_post_count
   after_destroy :decrement_post_count

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @post, url: user_posts_path(current_user), local: true do |form| %>
+<%= form_with model: @post, url: user_posts_path(current_user), html: { class: 'form-control' }, local: true do |form| %>
   <%= form.text_field :title, placeholder: 'Post Title' %>
   <%= form.text_area :text, placeholder: 'Post Content' %>
   <%= form.hidden_field :user_id, value: current_user.id %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,7 +20,7 @@
 
 
   <% if can? :destroy, @post %>
-    <%= button_to "Delete post", user_post_path(user_id: @post.user.id, post_id: @post.id), method: :delete, class: "btn", data: { confirm: 'Are you sure?' }  %>
+    <%= button_to "Delete post", user_post_path(user_id: @post.user.id, post_id: @post.id), method: :delete, class: "btn"  %>
   <% end %>
 
     <%= form_with(model: current_user.comments.build, url: user_post_comments_path(@post.user, @post), html: {class: 'form-control'}) do |form| %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,22 +9,23 @@
   <p class="post-content"><%= @post.text %></p>
   <div class="like_and_comment_container">
   <% if current_user.likes?(@post) %>
-    <%= form_with(model: @like, url: user_post_likes_path(post_id: @post.id, id: @like), method: :delete) do |form| %>
-      <%= form.button type: :submit, class: "btn" do %>
-        Unlike
-      <% end %>
+    <%= button_to(user_post_likes_path(post_id: @post.id, id: @like), method: :delete, class: "btn") do %>
+      Unlike
     <% end %>
   <% else %>
-    <%= form_with model: @like, url: user_post_likes_path(post_id: @post.id) do |form| %>
-      <%= form.button type: :submit, class: "btn" do %>
-        Like
-      <% end %>
+    <%= button_to(user_post_likes_path(post_id: @post.id), method: :post, class: "btn") do %>
+      Like
     <% end %>
   <% end %>
 
-    <%= form_with(model: current_user.comments.build, url: user_post_comments_path(@post.user, @post)) do |form| %>
-      <%= form.text_area :text, placeholder: 'Add a comment' %>
-      <%= form.button type: :submit, class: "btn" do %>
+
+  <% if can? :destroy, @post %>
+    <%= button_to "Delete post", user_post_path(user_id: @post.user.id, post_id: @post.id), method: :delete, class: "btn", data: { confirm: 'Are you sure?' }  %>
+  <% end %>
+
+    <%= form_with(model: current_user.comments.build, url: user_post_comments_path(@post.user, @post), html: {class: 'form-control'}) do |form| %>
+      <%= form.text_field :text, placeholder: 'Add a comment' %>
+      <%= form.button type: :submit, class: "btn btn-block" do %>
         Comment
       <% end %>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,9 +18,8 @@
     <% end %>
   <% end %>
 
-
   <% if can? :destroy, @post %>
-    <%= button_to "Delete post", user_post_path(user_id: @post.user.id, post_id: @post.id), method: :delete, class: "btn"  %>
+    <%= button_to "Delete post", user_post_path(user_id: @post.user.id, post_id: @post.id), method: :delete, class: "btn", data: { confirm: 'Are you sure?' }  %>
   <% end %>
 
     <%= form_with(model: current_user.comments.build, url: user_post_comments_path(@post.user, @post), html: {class: 'form-control'}) do |form| %>
@@ -34,6 +33,9 @@
     <% @post.comments.each do |comment| %>
       <li>
         <p><strong><a href="/users/<%= comment.user.id %> %>"><%= comment.user.name %></a>:</strong> <%= comment.text %></p>
+        <% if can? :destroy, comment %>
+            <%= button_to "Delete", user_post_comment_path(user_id: comment.author_id, post_id: comment.post.id, id: comment.id), method: :delete, class: "btn"  %>
+          <% end %>
       </li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   root "users#index"
   resources :users, only: [:index, :show] do
-    resources :posts, only: [:index, :show, :new, :create] do
-      resources :comments, only: [:create]
+    resources :posts, only: [:index, :show, :new, :create, :destroy] do
+      resources :comments, only: [:create, :destroy]
       resource :likes, only: [:create, :destroy]
     end
   end

--- a/db/migrate/20230727213418_add_role_to_users.rb
+++ b/db/migrate/20230727213418_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_010827) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_213418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_010827) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
### Description:
This pull request adds the required functionality to enable post and comment deleting in the project while ensuring that only authorized users can perform these actions. We have implemented CanCanCan for user authorization based on their roles.

### Changes Made:
1. Installed CanCanCan: Added the CanCanCan gem to the Gemfile and ran the necessary installation commands to set it up in the project.

2. Added Role Column to Users Table: Created a migration to add a `role` column to the `users` table to handle user roles. The `role` column accepts string values to represent different roles.

3. Implemented Post Deleting Functionality: Added the necessary logic to enable authorized users to delete their own posts or any post if they have an "admin" role. A "Delete" button is now displayed in the view for authorized users, and only they can see it.

4. Implemented Comment Deleting Functionality: Implemented the logic to allow authorized users to delete their own comments or any comment if they have an "admin" role. A "Delete" button is added to the view for authorized users, and only they can see it.

Testing:
We extensively tested the post and comment deleting functionality in various scenarios to ensure proper authorization and security. We also checked that the "Delete" button is correctly displayed for authorized users and hidden for unauthorized users.

### Collaborators:
- @christianonoh 
- @Ellyboi 

Thank you for reviewing this pull request. Please feel free to provide feedback or ask for any additional information if needed. We hope this contribution improves the project's functionality and security.
